### PR TITLE
Disable java attacher on windows

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -458,7 +458,7 @@ func (s *serverRunner) run(listener net.Listener) error {
 	}
 
 	if s.config.JavaAttacherConfig.Enabled {
-		if eac == "" {
+		if eac == "" && runtime.GOOS != "windows" {
 			// We aren't running in a cloud environment
 			go func() {
 				attacher := javaattacher.New(s.config.JavaAttacherConfig)

--- a/beater/java_attacher/set_run_as_user.go
+++ b/beater/java_attacher/set_run_as_user.go
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !windows
+// +build !windows
+
+package javaattacher
+
+import (
+	"fmt"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strconv"
+	"syscall"
+)
+
+func (j *JavaAttacher) setRunAsUser(jvm *JvmDetails, cmd *exec.Cmd) error {
+	currentUser, err := user.Current()
+	if err != nil {
+		j.logger.Infof("failed to get the current user: %v", err)
+	} else {
+		j.logger.Debugf("current user: %v", currentUser)
+	}
+	if currentUser.Gid != jvm.gid || currentUser.Uid != jvm.uid {
+		uid, err := strconv.ParseInt(jvm.uid, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid UID '%v': %v", jvm.uid, err)
+		}
+		gid, err := strconv.ParseInt(jvm.gid, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid GID '%v': %v", jvm.gid, err)
+		}
+
+		if runtime.GOOS != "windows" {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+			cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
+		}
+	}
+	return nil
+}

--- a/beater/java_attacher/set_run_as_user_windows.go
+++ b/beater/java_attacher/set_run_as_user_windows.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package javaattacher
+
+import (
+	"os/exec"
+)
+
+func (j *JavaAttacher) setRunAsUser(_ *JvmDetails, _ *exec.Cmd) error {
+	return nil
+}


### PR DESCRIPTION
Do not enable java agent attacher on windows and use build flags to avoid build issues when using `cmd.SysProcAttr.Credential` (not available on windows). 